### PR TITLE
Beheer: fix kapotte links

### DIFF
--- a/js/config.mjs
+++ b/js/config.mjs
@@ -77,22 +77,22 @@ loadRespecWithConfiguration({
     },
     "SAML2.CORE": {
       title: "Assertions and Protocols for the OASIS Security Assertion Markup Language (SAML) V2.0 – Errata Composite",
-      href: "https://groups.oasis-open.org/higherlogic/ws/public/document?document_id=56776",
+      href: "https://groups.oasis-open.org/higherlogic/ws/public/download/56776/sstc-saml-core-errata-2.0-wd-07.pdf",
       publisher: "OASIS"
     },
     "SAML2.PROFILES": {
       title: "Profiles for the OASIS Security Assertion Markup Language (SAML) V2.0 – Errata Composite",
-      href: "https://groups.oasis-open.org/higherlogic/ws/public/document?document_id=56782",
+      href: "https://groups.oasis-open.org/higherlogic/ws/public/download/56782/sstc-saml-profiles-errata-2.0-wd-07.pdf",
       publisher: "OASIS"
     },
     "SAML2.METADATA": {
       title: "Metadata for the OASIS Security Assertion Markup Language (SAML) V2.0 – Errata Composite",
-      href: "https://groups.oasis-open.org/higherlogic/ws/public/document?document_id=56785",
+      href: "https://groups.oasis-open.org/higherlogic/ws/public/download/56785/sstc-saml-metadata-errata-2.0-wd-05.pdf",
       publisher: "OASIS"
     },
     "SAML2.BINDINGS": {
       title: "Bindings for the OASIS Security Assertion Markup Language (SAML) V2.0 – Errata Composite",
-      href: "https://groups.oasis-open.org/higherlogic/ws/public/document?document_id=56779",
+      href: "https://groups.oasis-open.org/higherlogic/ws/public/download/56779/sstc-saml-bindings-errata-2.0-wd-06.pdf",
       publisher: "OASIS"
     },
     "SAML2.ERRATA.05": {

--- a/js/config.mjs
+++ b/js/config.mjs
@@ -67,7 +67,7 @@ loadRespecWithConfiguration({
     },
     SAML2: {
       title: "Security Assertion Markup Language (SAML) V2.0",
-      href: "https://wiki.oasis-open.org/security/FrontPage",
+      href: "https://www.oasis-open.org/standard/saml/",
       publisher: "OASIS"
     },
     "SAML2.TO": {

--- a/js/config.mjs
+++ b/js/config.mjs
@@ -77,22 +77,22 @@ loadRespecWithConfiguration({
     },
     "SAML2.CORE": {
       title: "Assertions and Protocols for the OASIS Security Assertion Markup Language (SAML) V2.0 – Errata Composite",
-      href: "https://www.oasis-open.org/committees/download.php/56776/sstc-saml-core-errata-2.0-wd-07.pdf",
+      href: "https://groups.oasis-open.org/higherlogic/ws/public/document?document_id=56776",
       publisher: "OASIS"
     },
     "SAML2.PROFILES": {
       title: "Profiles for the OASIS Security Assertion Markup Language (SAML) V2.0 – Errata Composite",
-      href: "https://www.oasis-open.org/committees/download.php/56782/sstc-saml-profiles-errata-2.0-wd-07.pdf",
+      href: "https://groups.oasis-open.org/higherlogic/ws/public/document?document_id=56782",
       publisher: "OASIS"
     },
     "SAML2.METADATA": {
       title: "Metadata for the OASIS Security Assertion Markup Language (SAML) V2.0 – Errata Composite",
-      href: "https://www.oasis-open.org/committees/download.php/56785/sstc-saml-metadata-errata-2.0-wd-05.pdf",
+      href: "https://groups.oasis-open.org/higherlogic/ws/public/document?document_id=56785",
       publisher: "OASIS"
     },
     "SAML2.BINDINGS": {
       title: "Bindings for the OASIS Security Assertion Markup Language (SAML) V2.0 – Errata Composite",
-      href: "https://www.oasis-open.org/committees/download.php/56779/sstc-saml-bindings-errata-2.0-wd-06.pdf",
+      href: "https://groups.oasis-open.org/higherlogic/ws/public/document?document_id=56779",
       publisher: "OASIS"
     },
     "SAML2.ERRATA.05": {
@@ -125,8 +125,8 @@ loadRespecWithConfiguration({
       publisher: "W3C"
     },
     "BSNk.DEC": {
-      title: "BSNk Decryptiecomponent",
-      href: "https://wiki.bsn-koppelregister.nl/display/DC/",
+      title: "BSNk PP technische specificaties",
+      href: "https://gitlab.com/logius/bsnk/bsnk-techspecs/bsnk/-/raw/main/BPTSlive.pdf",
       publisher: "Logius"
     },
   },

--- a/spec/frameworks_rd_ad_bvd.md
+++ b/spec/frameworks_rd_ad_bvd.md
@@ -57,6 +57,6 @@ A [=RD=] that supports [=SSO=] to [=DV=]s or [=LC=]s must propagate logout reque
 Step&nbsp;#|Route|Message|Endpoint|Binding|Meta-data
 ---|---|---|---|---|---
 4 + 5|[=RD=] (&rarr;[=UA=])&rarr;[=AD=]|[Logout Request](#rd-logout-request-message 'Specification of Federated logout request message of DV/LC to RD')|[=ad-metadata/SingleLogoutService=]|HTTP-POST|[AD/BVD](#ad-bvd-metadata)
-7 + 8|[=AD=]/[=BVD=] (&rarr;[=UA=]) &rarr;[=RD=]|[Logout Response](#rd-logout-response-message)|[=rd-sp-entitydescriptor/SingleLogoutService=]|HTTP-POST|[RD]("#rd-sp-metadata")</a>
+7 + 8|[=AD=]/[=BVD=] (&rarr;[=UA=]) &rarr;[=RD=]|[Logout Response](#rd-logout-response-message)|[=rd-sp-entitydescriptor/SingleLogoutService=]|HTTP-POST|[RD](#rd-sp-metadata)</a>
 
 </span>

--- a/spec/messages_dv_rd.md
+++ b/spec/messages_dv_rd.md
@@ -48,7 +48,7 @@ Artifacts are stored by [=RD=] for a maximum of 15 minutes and can only be retri
 
 **Step 11**
 
-[=RD=] replies with an [Artifact Response message](#dv-artifact-response) that belongs to the [=Artifact=]. In this message, [=RD=] provides an [Assertion](#dv-authn-response-assertion) that includes the authentication result and optionally the representation selection. And, if the authentication / representation selection was successful, the requested (encrypted) identifier(s) and attribute(s) of the [=EU=] and optionally the [=Represented Party=]. The identities and attributes are encrypted so that only the intended [=DV=](s) can obtain the plain text value.
+[=RD=] replies with an [Artifact Response message](#dv-artifact-response) that belongs to the [=Artifact=]. In this message, [=RD=] provides an [Assertion](#dv-authn-response-assertion) that includes the authentication result and optionally the representation selection. And, if the authentication / representation selection was successful, the requested (encrypted) identifier(s) and attribute(s) of the [=EU=] and optionally the [=Represented Party=]. The identities and attributes are encrypted so that only the intended [=DV=]\(s\) can obtain the plain text value.
 
 If the authentication or attempt to select representation was unsuccessful, it is indicated in the Status Code of the Response message and if possible, a reason is given so that the web service can inform the [=EU=].
 

--- a/spec/messages_rd_ad_bvd.md
+++ b/spec/messages_rd_ad_bvd.md
@@ -42,7 +42,7 @@ An [Artifact Response message](#rd-artifact-response-message) is valid for a max
 
 **Step 11**
 
-[=AD=]/[=BVD=] replies with an [Artifact Response message](#rd-artifact-response) that belongs to the [=Artifact=]. In this message, [=AD=]/[=BVD=] provides an [Assertion]( #rd-authn-response-assertion) that includes the authentication result or the proof of representation. And, if the authentication / representation selection was successful, the requested (encrypted) identifier(s) and attribute(s) of the [=EU=] or the [=Represented Party=]. The identities and attributes are encrypted so that only the intended [=DV=](s) can obtain the plain text value.
+[=AD=]/[=BVD=] replies with an [Artifact Response message](#rd-artifact-response) that belongs to the [=Artifact=]. In this message, [=AD=]/[=BVD=] provides an [Assertion]( #rd-authn-response-assertion) that includes the authentication result or the proof of representation. And, if the authentication / representation selection was successful, the requested (encrypted) identifier(s) and attribute(s) of the [=EU=] or the [=Represented Party=]. The identities and attributes are encrypted so that only the intended [=DV=]\(s\) can obtain the plain text value.
 
 If the authentication or attempt to select representation was unsuccessful, it is indicated in the Status Code of the Response message and if possible, a reason is given so that the [=DV=] can inform the [=EU=].
 


### PR DESCRIPTION
Op dit moment faalt de link checker. Dat komt enerzijds omdat er Oasis
documenten zijn die redirecten. Daar gebruiken we nu de URL na redirect.

Ook is de BSNk link niet publiekelijk beschikbaar. In plaats daarvan linken
we nu naar de technische specificaties zoals gelinkt vanaf
https://www.logius.nl/onze-dienstverlening/toegang/voorzieningen/bsnk-pp/documentatie