### PR TITLE
Beheer: fix WCAG issues

### DIFF
--- a/spec/messages_dv_rd.md
+++ b/spec/messages_dv_rd.md
@@ -359,7 +359,7 @@ Upon decryption, elements without an [=dv-attributestatement/EncryptedKey=] inte
 ##### Generic attributes
 In all cases the following attributes will be provided as an unencrypted [=dv-attributestatement/Attribute=].
 
-Attribute|1..n|Attribute [=dv-attributestatement/Name=]|Description
+Attribute|1..n|Attribute Name|Description
 ---|---|---|---
 ServiceUUID|1|`[=dv-attributestatement/Name=]="urn:nl-eid-gdi:1.0:ServiceUUID"`	
 -AttributeValue|1..n| |The ServiceUUID of the [=Service Catalog=] for which this Assertions is intended as indicated in the [AuthN Request message](#dv-authn-request-message). In case of legal representation the [=ServiceUUID=] will be a copy of [=ServiceUUID/Attribute=] in [AuthN Request message](#dv-authn-request-message)
@@ -368,7 +368,7 @@ ServiceUUID|1|`[=dv-attributestatement/Name=]="urn:nl-eid-gdi:1.0:ServiceUUID"`
 ##### Attribute types in case of legal representation {#attribute-for-legal-representation}
 In case of legal representation, via [=BVD=] the following attribute will be provided as an unencrypted [=dv-attributestatement/Attribute=].
 
-Type|1..n|Attribute [=dv-attributestatement/Name=]|Description
+Type|1..n|Attribute Name|Description
 ---|---|---|---
 RepresentationType|0-1|`[=dv-attributestatement/Name=]="urn:nl-eid-gdi:1.1:RepresentationType"`| Optional for DigiD Machtigen, required for any type of legal representation by the [=BVD=]
 -AttributeValue|1..n| |The [type of representation ](#representation-types), to be used by Service Provider [=DV=] for access decision<br/>multiple values of [=Legal Representation=] allowed.
@@ -376,7 +376,7 @@ RepresentationType|0-1|`[=dv-attributestatement/Name=]="urn:nl-eid-gdi:1.1:Repre
 ##### Attribute types in case of authentication
 In case of authentication the following attributes will be provided as [=dv-attributestatement/EncryptedID=].
 
-Attribute|1..n|Attribute [=dv-attributestatement/Name=]|Description
+Attribute|1..n|Attribute Name|Description
 ---|---|---|---
 ActingSubjectID|1|`[=dv-attributestatement/Name=]="urn:nl-eid-gdi:1.0:ActingSubjectID"`.	
 -AttributeValue|1..n| |All contain identities of the same [=EU=].
@@ -384,7 +384,7 @@ ActingSubjectID|1|`[=dv-attributestatement/Name=]="urn:nl-eid-gdi:1.0:ActingSubj
 ##### Attribute types issuer in case of representation
 In case of representation the following attributes will be provided as [=dv-attributestatement/EncryptedID=]
 
-Type|1..n|Attribute [=dv-attributestatement/Name=]|Description
+Type|1..n|Attribute Name|Description
 ---|---|---|---
 <dfn title="Identity of the EndUser (EU)" data-dfn-for="dv-attributestatement">ActingSubjectID</dfn>|1|`[=dv-attributestatement/Name=]="urn:nl-eid-gdi:1.0:ActingSubjectID"`| Identity of the EndUser ([=EU=])
 -AttributeValue|1..n| |The (encrypted) ActingSubjectID as received from the AD at which the [=EU=] was authenticated.<br/>All contain identities of the same [=EU=].
@@ -394,7 +394,7 @@ Type|1..n|Attribute [=dv-attributestatement/Name=]|Description
 ##### Attribute type conversion eTD {#attribute-type-conversion-etd}
 In case of authentication with eTD the following Attributes will be provided as [EncryptedID](#dv-encryptedid)
 
-Type|1..n|eTD [=dv-attributestatement/Name=]|[=ST-SAML=] [=dv-attributestatement/Name=]|Description
+Type|1..n|eTD Name|ST-SAML Name|Description
 ---|---|---|---|---
 Attribute|0..1|urn:etoegang:core:ActingSubjectID|urn:nl-eid-gdi:1.0:ActingSubjectID|Identity of the EndUser ([=EU=]) 
 --AttributeValue|1..n| | |All contain identities of the same [=EU=].

--- a/spec/messages_dv_rd.md
+++ b/spec/messages_dv_rd.md
@@ -88,7 +88,7 @@ Sender|Recipient
 > See also [Example AuthnRequest DV for RD](#example-authnrequest)
 
 
-Element/@Attribute|0..n|Description<br/>Issuer = [=DV=] or [=LC=]<br/>Recipient = [=RD=]
+Element/@Attribute|0..n|Description<br/>Issuer = DV or LC<br/>Recipient = RD
 ---|---|---
 &#64;<dfn title="Unique message identifier. MUST identify the message uniquely within the scope of the sender and receiver for a period of at least 12 months." data-dfn-for="dv-authn-request-message">ID</dfn>|1|Unique message identifier. MUST identify the message uniquely within the scope of the sender and receiver for a period of at least 12 months.
 &#64;<dfn title="Version of the SAML protocol. The value MUST be 2.0." data-dfn-for="dv-authn-request-message">Version</dfn>|1|Version of the SAML protocol. The value MUST be `2.0`.

--- a/spec/messages_rd_ad_bvd.md
+++ b/spec/messages_rd_ad_bvd.md
@@ -88,7 +88,7 @@ Sender|Recipient
 
 ##### AuthN-Request differences between DV/LC&rarr;RD, RD&rarr;AD and RD&rarr;BVD {#authnrequest-diffs}
 
-Element/@Attribute|[=DV=]/[=LC=]&rarr;[=RD=]|[=RD=]&rarr;[=AD=]|[=RD=]&rarr;[=BVD=]
+Element/@Attribute|DV / LC&rarr;RD|RD&rarr;AD|RD&rarr;BVD
 ---|---|---|---
 [=dv-authn-request-message/AttributeConsumingServiceIndex=]|If present, [=dv-authn-request-message/Extensions=] MUST NOT be present.</br>Forbidden for [=LC=]|MUST not be present (ignored)|MUST not be present (ignored)
 [=dv-authn-request-message/Extensions=]|If present, [=dv-authn-request-message/AttributeConsumingServiceIndex=] MUST NOT be present.</br>Mandatory for [=LC=]|Mandatory|Mandatory
@@ -186,7 +186,7 @@ The [SAML Response Message](#rd-authn-response-message) to the [AuthN Request me
 
 ##### Assertion and AttributeStatement differences between DV/LC&larr;RD and RD&larr;AD/BVD {#assertion-diffs}
 
-Element/@Attribute|[=DV=]/[=LC=]&larr;[=RD=]|[=RD=]&larr;[=AD=]|[=RD=]&larr;[=BVD=]
+Element/@Attribute|DV / LC&larr;RD|RD&larr;AD|RD&larr;BVD
 ---|---|---|---
 [=dv-authn-response-assertion/Conditions=]</br>-[=dv-authn-response-assertion/AudienceRestriction=]<br/>--[=dv-authn-response-assertion/Audience=]|MUST contain [=EntityID=] of [=DV=] and (if applicable) [=LC=].|MUST contain [=EntityID=] of [=RD=] and (in case of representation)[=BVD=] .|MUST contain [=EntityID=] of [=RD=].
 [=dv-authn-response-assertion/AuthnStatement=]</br>‐[=dv-authn-response-assertion/AuthnContext=]</br>‐‐[=dv-authn-response-assertion/AuthnContextClassRef=]|MUST be present.|MUST be present.|MUST be `urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified`.

--- a/spec/types.md
+++ b/spec/types.md
@@ -73,7 +73,7 @@ The `<index>` is a number with 4 positions between 0000 and 8999 that can be sel
 ### Level of Assurance {#level-of-assurance}
 The table shows the four Levels of Assurance supported by [=ST-SAML=] and the corresponding urn’s which are used in the SAML messages.
 
-[=LoA=]|urn
+LoA|urn
 ---|---
 Basis|`http://eID.logius.nl/LoA/basic`
 Midden|`http://eidas.europa.eu/LoA/low`


### PR DESCRIPTION
De links in een table header hebben geen goede contrast. Omdat
er al genoeg linkjes naar die definities zijn, kunnen we ze beter
weglaten en zo de toegankelijkheid verbeteren.