### PR TITLE
Fix dubbele box in mermaid figure 7

### DIFF
--- a/media/saml-authentication-flow-dv-lc-rd-authn-request.mermaid
+++ b/media/saml-authentication-flow-dv-lc-rd-authn-request.mermaid
@@ -15,13 +15,11 @@ rect rgba(255,0,0,.1)
     A->>C: AuthnRequest
 end
 rect rgba(75, 75, 75,.4)
-rect rgba(75, 75, 75,.4)
     Note over D,E: Out of Scope: see RD#8594;AD/BVD
     C-->>A:
     A->>E:
     E-->>A:
     A->>C:
-end
 end
 C-->>A: artifact
 A->>B: artifact


### PR DESCRIPTION
In het verleden moest de laatste box in Mermaid dubbel omdat deze anders niet getoond werd. Dat is nu niet meer en heb ik de dubbele box uit het mermaid plaatje gehaalt. Alleen nog Figure 7.