### PR TITLE
Beheer: zet develop op werkversie

### DIFF
--- a/js/config.mjs
+++ b/js/config.mjs
@@ -8,7 +8,7 @@ export const baseConfig = {
   useLogo: true,
   useLabel: true,
   license: "cc-by",
-  specStatus: "DEF",
+  specStatus: "WV",
   specType: "HR",
   pubDomain: "st",
   shortName: "saml",


### PR DESCRIPTION
De standaard heeft nu een `main` branch, dus kan `develop` weer als werkversie worden beschouwd.